### PR TITLE
Change french translation

### DIFF
--- a/src/javascript/Localizations.js
+++ b/src/javascript/Localizations.js
@@ -21,7 +21,7 @@ const Localizations = {
     'da': "Myriad. En mønt til alle.",
     'de': "Myriad. Eine Münze für alle.",
     'es': "Myriad. Una moneda para todos.",
-    'fr': "Myriad. Une pièce de monnaie pour tout le monde.",
+    'fr': "Myriad. Une monnaie pour tout le monde.",
     'it': "Myriad. Una moneta per tutti.",
     'ja': "Myriad. みんなのためのコイン。",
     'ko': "Myriad. 모두를위한 동전.",


### PR DESCRIPTION
"Une monnaie" would be better. It translates to "a currency" whereas "une pièce de monnaie" translates to a coin, but like an actual physical coin.