### PR TITLE
Remove Electrum-myr from website

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,14 +185,6 @@
                 <h5 localization="wallets-other-title">Other</h5>
 
                 <div class="platform">
-                  <h6>Electrum</h6>
-                  <a href="https://github.com/cryptapus/electrum-myr" class="btn btn-shark" target="_blank"><i class="ion-social-github hidden-sm"></i> GitHub</a>
-                  <a href="https://github.com/cryptapus/electrum-myr/releases/download/v2.7.17.2/electrum-myr-2.7.17.2-setup.win.exe" class="btn btn-shark" target="_blank"><i class="ion-social-windows hidden-sm"></i> <span localization="wallets-other-windows">Windows</span></a>
-                  <a href="https://github.com/cryptapus/electrum-myr/releases/download/v2.7.17.2/Electrum_myr-2.7.17.2.linux.tar.gz" class="btn btn-shark" target="_blank"><i class="ion-social-tux hidden-sm"></i> <span localization="wallets-other-linux">Linux</span></a>
-                  <a href="https://github.com/cryptapus/electrum-myr/releases/download/v2.7.17.2/electrum-myr-2.7.17.2-macosx.dmg" class="btn btn-shark" target="_blank"><i class="ion-social-apple hidden-sm"></i> Mac OSX</a>
-                </div>
-
-                <div class="platform">
                   <h6>JSWallet</h6>
                   <a href="https://cryptap.us/myr/jswallet" class="btn btn-shark" target="_blank"><i class="ion-code hidden-sm"></i> <span localization="wallets-other-download">Download</span></a>
                 </div>


### PR DESCRIPTION
I recommend that we remove Electrum-myr from the myriadcoin.org website due to some outstanding bugs:

https://github.com/cryptapus/electrum-myr/issues/1

https://github.com/cryptapus/electrum-myr/issues/5